### PR TITLE
Various reorganizations

### DIFF
--- a/cl-oid-connect.asd
+++ b/cl-oid-connect.asd
@@ -17,9 +17,11 @@
                 :lquery
                 :plump
                 :cl-who
-                :postmodern)
+                :postmodern
+                :iterate)
   :serial t
-  :components ((:file "package")
+  :components ((:file "utils")
+               (:file "package")
                (:file "cl-oid-connect")))
 
 

--- a/demo.lisp
+++ b/demo.lisp
@@ -13,17 +13,14 @@
 (ql:quickload :iterate)
 (ql:quickload :jonathan)
 
-(declaim (optimize (speed 0) (safety 2) (debug 2)))
+(declaim (optimize (speed 0) (safety 3) (debug 2)))
 
 (push (cons "application" "rdf+xml") drakma:*text-content-types*)
 (push (cons "application" "rss+xml") drakma:*text-content-types*)
 (push (cons "text" "rss+xml") drakma:*text-content-types*)
 
-(defpackage whitespace.utils
-  (:use #:cl))
-(load "utils.lisp")
-
 (load "rss.lisp")
+
 
 (defpackage :whitespace
   (:use #:cl #:whitespace.utils #:whitespace.rss #:whitespace.tables))

--- a/package.lisp
+++ b/package.lisp
@@ -15,7 +15,9 @@
     #:lass
     #:lquery
     #:plump
-    #:sheeple)
+    #:sheeple
+    #:whitespace.utils
+    )
   (:export
     #:redirect-if-necessary
     #:def-route
@@ -24,5 +26,6 @@
     #:with-session
     #:assoc-cdr
     #:session ; private!!
+    #:vars-to-symbol-macrolets
     ))
 

--- a/utils.lisp
+++ b/utils.lisp
@@ -1,13 +1,69 @@
+(defpackage whitespace.utils
+  (:use #:cl #:alexandria #:iterate))
+
 (in-package whitespace.utils)
-(lquery:define-lquery-list-function tag-name (nodes &rest tags)
-  "Manipulate elements on the basis of there tag-name.
-   With no arguments, return their names else return
-   the corresponding tags."
-  (if (null tags)
-    (map 'vector #'plump:tag-name nodes)
-    (apply #'vector
-           (loop for node across nodes
-                 if (find (plump:tag-name node) tags :test #'string=)
-                 collect node))))
+
+(defun ensure-mapping (list)
+  "Make sure that each item of the list is a pair of symbols"
+  (mapcar (lambda (x) (if (symbolp x) (list x x) x)) list))
+(export 'ensure-mapping)
+
+(defun alist-string-hash-table (alist)
+  (alexandria:alist-hash-table alist :test #'string=))
+(export 'alist-string-hash-table)
+
+(defun make-pairs (symbols)
+  (cons 'list (iterate (for (key value) in symbols)
+                       (collect (list 'list* (symbol-name key) value)))))
+(export 'make-pairs)
+
+(defmacro copy-slots (slots from-v to-v)
+  (with-gensyms (from to)
+    `(let ((,from ,from-v) (,to ,to-v))
+       ,@(iterate (for (fro-slot to-slot) in (ensure-mapping slots))
+                  (collect `(setf (slot-value ,to ',to-slot) (slot-value ,from ',fro-slot))))
+       ,to)))
+(export 'copy-slots)
+
+
+(defun transform-alist (pair-transform alist)
+  (iterate (for (k . v) in-sequence alist)
+           (collect
+             (funcall pair-transform k v))))
+(export 'transform-alist)
+
+(defun %json-pair-transform (k v)
+  (cons (make-keyword (string-downcase k))
+        (typecase v
+          (string (coerce v 'simple-string))
+          (t v))))
+(export '%json-pair-transform)
+
+(defun %default-pair-transform (k v)
+  (cons (make-keyword (string-upcase k)) v))
+(export '%default-pair-transform)
+
+(defmacro default-when (default test &body body)
+  (once-only (default)
+    `(or (when ,test
+           ,@body)
+         ,default)))
+(export 'default-when)
+
+(defmacro transform-result ((list-transform pair-transform) &body alist)
+  `(funcall ,list-transform
+            (transform-alist ,pair-transform
+                             ,@alist)))
+(export 'transform-result)
+
+
+(defmacro slots-to-pairs (obj (&rest slots))
+  (once-only (obj)
+    (let* ((slots (ensure-mapping slots))
+           (bindings (iterate (for (slot v &key bind-from) in slots)
+                              (collect (or bind-from slot)))))
+      `(with-slots ,bindings ,obj
+         ,(make-pairs slots)))))
+(export 'slots-to-pairs)
 
 


### PR DESCRIPTION
Moving a bunch of macros and utilities out of rss.lisp to utils.lisp
to make them more reusable.

cl-oid-connect now depends on utils.

General clearnup
